### PR TITLE
Fix help doc keyboard shortcut typo

### DIFF
--- a/src/help.html
+++ b/src/help.html
@@ -100,7 +100,7 @@
         <strong>Keyboard</strong>
         <table class="keylist-table">
                 <tr>
-                <td><span class="kbd">Comnmand</span> + <span class="kbd">1</span></td>
+                <td><span class="kbd">Command</span> + <span class="kbd">1</span></td>
                 <td>Zoom in (using built-in MacOS zoom functionality. You must first enable use of Keyboard shortcuts in System Preferences > Accessibility > Zoom)</td>
             </tr>
             <tr>


### PR DESCRIPTION
## Summary
- correct 'Command' typo in help page

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eeaf36c208332bb4ef02d89631b2d