### PR TITLE
Fix missing delay before script typing

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -613,7 +613,7 @@ function pause(ms: number | undefined) {
 
 async function runScript() {
     const anyVisible = hideOverlayWindows();
-    pause(100);
+    await pause(100);
     if (currentScript.length === 0 && originalScript.length > 0) {
         currentScript = JSON.parse(JSON.stringify(originalScript))
     }


### PR DESCRIPTION
## Summary
- ensure `runScript` waits for pause before typing

## Testing
- `npx tsc` *(fails: Cannot find name 'require' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684ee9eb15cc8332a113397583e7f603